### PR TITLE
fix(countdown): count milliseconds down

### DIFF
--- a/2026/index.html
+++ b/2026/index.html
@@ -3021,8 +3021,13 @@
     if (reduceMotion) { cdMs.textContent = '.000'; return; }
     let lastUpdate = 0;
     function tickMs(now) {
+      const remaining = CD_TARGET - Date.now();
+      if (remaining <= 0) {
+        cdMs.textContent = '.000';
+        return;
+      }
       if (now - lastUpdate >= 33) {
-        const ms = Math.max(0, CD_TARGET - Date.now()) % 1000;
+        const ms = remaining % 1000;
         cdMs.textContent = '.' + String(ms).padStart(3, '0');
         lastUpdate = now;
       }

--- a/2026/index.html
+++ b/2026/index.html
@@ -3022,7 +3022,7 @@
     let lastUpdate = 0;
     function tickMs(now) {
       if (now - lastUpdate >= 33) {
-        const ms = Date.now() % 1000;
+        const ms = Math.max(0, CD_TARGET - Date.now()) % 1000;
         cdMs.textContent = '.' + String(ms).padStart(3, '0');
         lastUpdate = now;
       }


### PR DESCRIPTION
## Summary

- Count the countdown millisecond ticker from the remaining event time instead of wall-clock milliseconds.

## Testing

- Not run; one-line static HTML countdown calculation change.
